### PR TITLE
Stop clobbering all forceloads

### DIFF
--- a/darcenos-minecarts-slower/data/vanillapluscarts/function/add_forceload.mcfunction
+++ b/darcenos-minecarts-slower/data/vanillapluscarts/function/add_forceload.mcfunction
@@ -1,0 +1,3 @@
+execute unless function vanillapluscarts:forceload_query run function vanillapluscarts:log_forceload
+
+forceload add ~ ~ ~ ~

--- a/darcenos-minecarts-slower/data/vanillapluscarts/function/forceload_query.mcfunction
+++ b/darcenos-minecarts-slower/data/vanillapluscarts/function/forceload_query.mcfunction
@@ -1,0 +1,1 @@
+return run forceload query ~ ~

--- a/darcenos-minecarts-slower/data/vanillapluscarts/function/forceload_remove.mcfunction
+++ b/darcenos-minecarts-slower/data/vanillapluscarts/function/forceload_remove.mcfunction
@@ -1,0 +1,1 @@
+$forceload remove $(x) $(z)

--- a/darcenos-minecarts-slower/data/vanillapluscarts/function/load.mcfunction
+++ b/darcenos-minecarts-slower/data/vanillapluscarts/function/load.mcfunction
@@ -1,2 +1,4 @@
 scoreboard objectives add VanillaPlusCartsXSpeed dummy
 scoreboard objectives add VanillaPlusCartsZSpeed dummy
+
+data merge storage vanillapluscarts:global {chunks:[]}

--- a/darcenos-minecarts-slower/data/vanillapluscarts/function/load.mcfunction
+++ b/darcenos-minecarts-slower/data/vanillapluscarts/function/load.mcfunction
@@ -1,4 +1,4 @@
 scoreboard objectives add VanillaPlusCartsXSpeed dummy
 scoreboard objectives add VanillaPlusCartsZSpeed dummy
 
-data merge storage vanillapluscarts:global {chunks:[]}
+execute unless data storage vanillapluscarts:global chunks run data merge storage vanillapluscarts:global {chunks:[]}

--- a/darcenos-minecarts-slower/data/vanillapluscarts/function/log_forceload.mcfunction
+++ b/darcenos-minecarts-slower/data/vanillapluscarts/function/log_forceload.mcfunction
@@ -1,0 +1,5 @@
+data modify storage vanillapluscarts:global chunks insert 0 value {}
+data modify storage vanillapluscarts:global chunks[0].z set from entity @s Pos[2]
+execute store result storage vanillapluscarts:global chunks[0].z int 1 run data get storage vanillapluscarts:global chunks[0].z
+data modify storage vanillapluscarts:global chunks[0].x set from entity @s Pos[0]
+execute store result storage vanillapluscarts:global chunks[0].x int 1 run data get storage vanillapluscarts:global chunks[0].x

--- a/darcenos-minecarts-slower/data/vanillapluscarts/function/remove_all_forceload.mcfunction
+++ b/darcenos-minecarts-slower/data/vanillapluscarts/function/remove_all_forceload.mcfunction
@@ -1,4 +1,4 @@
-execute store success storage vanillapluscarts:global success byte 1 run function vanillapluscarts:forceload_remove with storage vanillapluscarts:global chunks[0]
+execute run function vanillapluscarts:forceload_remove with storage vanillapluscarts:global chunks[0]
 
 # pop
 data remove storage vanillapluscarts:global chunks[0]

--- a/darcenos-minecarts-slower/data/vanillapluscarts/function/remove_all_forceload.mcfunction
+++ b/darcenos-minecarts-slower/data/vanillapluscarts/function/remove_all_forceload.mcfunction
@@ -1,0 +1,7 @@
+execute store success storage vanillapluscarts:global success byte 1 run function vanillapluscarts:forceload_remove with storage vanillapluscarts:global chunks[0]
+
+# pop
+data remove storage vanillapluscarts:global chunks[0]
+
+# recurse
+execute if data storage vanillapluscarts:global chunks[0] run function vanillapluscarts:remove_all_forceload

--- a/darcenos-minecarts-slower/data/vanillapluscarts/function/tick.mcfunction
+++ b/darcenos-minecarts-slower/data/vanillapluscarts/function/tick.mcfunction
@@ -1,77 +1,77 @@
 execute as @e[type=minecraft:minecart] at @s if entity @e[type=!minecraft:minecart,distance=..0.5] run function vanillapluscarts:speed
 execute as @e[type=minecraft:chest_minecart] at @s if entity @e[type=!minecraft:minecart,distance=..0.5] run function vanillapluscarts:speed
 
-forceload remove all
+function vanillapluscarts:remove_all_forceload
 
-execute as @e[type=minecart] run execute at @s if entity @e[type=!minecraft:minecart,distance=..0.5] if block ~1 ~ ~ #minecraft:rails run forceload add ~ ~ ~ ~
-execute as @e[type=minecart] run execute at @s if entity @e[type=!minecraft:minecart,distance=..0.5] if block ~-1 ~ ~ #minecraft:rails run forceload add ~ ~ ~ ~ 
+execute as @e[type=minecart] run execute at @s if entity @e[type=!minecraft:minecart,distance=..0.5] if block ~1 ~ ~ #minecraft:rails run function vanillapluscarts:add_forceload
+execute as @e[type=minecart] run execute at @s if entity @e[type=!minecraft:minecart,distance=..0.5] if block ~-1 ~ ~ #minecraft:rails run function vanillapluscarts:add_forceload
 
-execute as @e[type=minecart] run execute at @s if entity @e[type=!minecraft:minecart,distance=..0.5] if block ~ ~ ~1 #minecraft:rails run forceload add ~ ~ ~ ~ 
-execute as @e[type=minecart] run execute at @s if entity @e[type=!minecraft:minecart,distance=..0.5] if block ~ ~ ~-1 #minecraft:rails run forceload add ~ ~ ~ ~
+execute as @e[type=minecart] run execute at @s if entity @e[type=!minecraft:minecart,distance=..0.5] if block ~ ~ ~1 #minecraft:rails run function vanillapluscarts:add_forceload
+execute as @e[type=minecart] run execute at @s if entity @e[type=!minecraft:minecart,distance=..0.5] if block ~ ~ ~-1 #minecraft:rails run function vanillapluscarts:add_forceload
 
-execute as @e[type=minecart] run execute at @s if entity @e[type=!minecraft:minecart,distance=..0.5] if block ~1 ~ ~1 #minecraft:rails run forceload add ~ ~ ~ ~ 
-execute as @e[type=minecart] run execute at @s if entity @e[type=!minecraft:minecart,distance=..0.5] if block ~-1 ~ ~-1 #minecraft:rails run forceload add ~ ~ ~ ~
+execute as @e[type=minecart] run execute at @s if entity @e[type=!minecraft:minecart,distance=..0.5] if block ~1 ~ ~1 #minecraft:rails run function vanillapluscarts:add_forceload
+execute as @e[type=minecart] run execute at @s if entity @e[type=!minecraft:minecart,distance=..0.5] if block ~-1 ~ ~-1 #minecraft:rails run function vanillapluscarts:add_forceload
 
-execute as @e[type=minecart] run execute at @s if entity @e[type=!minecraft:minecart,distance=..0.5] if block ~1 ~ ~1 #minecraft:rails run forceload add ~ ~ ~ ~ 
-execute as @e[type=minecart] run execute at @s if entity @e[type=!minecraft:minecart,distance=..0.5] if block ~1 ~ ~-1 #minecraft:rails run forceload add ~ ~ ~ ~
+execute as @e[type=minecart] run execute at @s if entity @e[type=!minecraft:minecart,distance=..0.5] if block ~1 ~ ~1 #minecraft:rails run function vanillapluscarts:add_forceload
+execute as @e[type=minecart] run execute at @s if entity @e[type=!minecraft:minecart,distance=..0.5] if block ~1 ~ ~-1 #minecraft:rails run function vanillapluscarts:add_forceload
 
-execute as @e[type=minecart] run execute at @s if entity @e[type=!minecraft:minecart,distance=..0.5] if block ~1 ~1 ~ #minecraft:rails run forceload add ~ ~ ~ ~ 
-execute as @e[type=minecart] run execute at @s if entity @e[type=!minecraft:minecart,distance=..0.5] if block ~1 ~-1 ~ #minecraft:rails run forceload add ~ ~ ~ ~
+execute as @e[type=minecart] run execute at @s if entity @e[type=!minecraft:minecart,distance=..0.5] if block ~1 ~1 ~ #minecraft:rails run function vanillapluscarts:add_forceload
+execute as @e[type=minecart] run execute at @s if entity @e[type=!minecraft:minecart,distance=..0.5] if block ~1 ~-1 ~ #minecraft:rails run function vanillapluscarts:add_forceload
 
-execute as @e[type=minecart] run execute at @s if entity @e[type=!minecraft:minecart,distance=..0.5] if block ~-1 ~1 ~ #minecraft:rails run forceload add ~ ~ ~ ~ 
-execute as @e[type=minecart] run execute at @s if entity @e[type=!minecraft:minecart,distance=..0.5] if block ~-1 ~-1 ~ #minecraft:rails run forceload add ~ ~ ~ ~
+execute as @e[type=minecart] run execute at @s if entity @e[type=!minecraft:minecart,distance=..0.5] if block ~-1 ~1 ~ #minecraft:rails run function vanillapluscarts:add_forceload
+execute as @e[type=minecart] run execute at @s if entity @e[type=!minecraft:minecart,distance=..0.5] if block ~-1 ~-1 ~ #minecraft:rails run function vanillapluscarts:add_forceload
 
-execute as @e[type=minecart] run execute at @s if entity @e[type=!minecraft:minecart,distance=..0.5] if block ~ ~1 ~1 #minecraft:rails run forceload add ~ ~ ~ ~ 
-execute as @e[type=minecart] run execute at @s if entity @e[type=!minecraft:minecart,distance=..0.5] if block ~ ~-1 ~1 #minecraft:rails run forceload add ~ ~ ~ ~
+execute as @e[type=minecart] run execute at @s if entity @e[type=!minecraft:minecart,distance=..0.5] if block ~ ~1 ~1 #minecraft:rails run function vanillapluscarts:add_forceload
+execute as @e[type=minecart] run execute at @s if entity @e[type=!minecraft:minecart,distance=..0.5] if block ~ ~-1 ~1 #minecraft:rails run function vanillapluscarts:add_forceload
 
-execute as @e[type=minecart] run execute at @s if entity @e[type=!minecraft:minecart,distance=..0.5] if block ~ ~1 ~-1 #minecraft:rails run forceload add ~ ~ ~ ~ 
-execute as @e[type=minecart] run execute at @s if entity @e[type=!minecraft:minecart,distance=..0.5] if block ~ ~-1 ~-1 #minecraft:rails run forceload add ~ ~ ~ ~
+execute as @e[type=minecart] run execute at @s if entity @e[type=!minecraft:minecart,distance=..0.5] if block ~ ~1 ~-1 #minecraft:rails run function vanillapluscarts:add_forceload
+execute as @e[type=minecart] run execute at @s if entity @e[type=!minecraft:minecart,distance=..0.5] if block ~ ~-1 ~-1 #minecraft:rails run function vanillapluscarts:add_forceload
 
-execute as @e[type=minecart] run execute at @s if entity @e[type=!minecraft:minecart,distance=..0.5] if block ~1 ~1 ~1 #minecraft:rails run forceload add ~ ~ ~ ~ 
-execute as @e[type=minecart] run execute at @s if entity @e[type=!minecraft:minecart,distance=..0.5] if block ~1 ~-1 ~1 #minecraft:rails run forceload add ~ ~ ~ ~
+execute as @e[type=minecart] run execute at @s if entity @e[type=!minecraft:minecart,distance=..0.5] if block ~1 ~1 ~1 #minecraft:rails run function vanillapluscarts:add_forceload
+execute as @e[type=minecart] run execute at @s if entity @e[type=!minecraft:minecart,distance=..0.5] if block ~1 ~-1 ~1 #minecraft:rails run function vanillapluscarts:add_forceload
 
-execute as @e[type=minecart] run execute at @s if entity @e[type=!minecraft:minecart,distance=..0.5] if block ~-1 ~1 ~-1 #minecraft:rails run forceload add ~ ~ ~ ~ 
-execute as @e[type=minecart] run execute at @s if entity @e[type=!minecraft:minecart,distance=..0.5] if block ~-1 ~-1 ~-1 #minecraft:rails run forceload add ~ ~ ~ ~
+execute as @e[type=minecart] run execute at @s if entity @e[type=!minecraft:minecart,distance=..0.5] if block ~-1 ~1 ~-1 #minecraft:rails run function vanillapluscarts:add_forceload
+execute as @e[type=minecart] run execute at @s if entity @e[type=!minecraft:minecart,distance=..0.5] if block ~-1 ~-1 ~-1 #minecraft:rails run function vanillapluscarts:add_forceload
 
-execute as @e[type=minecart] run execute at @s if entity @e[type=!minecraft:minecart,distance=..0.5] if block ~1 ~1 ~1 #minecraft:rails run forceload add ~ ~ ~ ~ 
-execute as @e[type=minecart] run execute at @s if entity @e[type=!minecraft:minecart,distance=..0.5] if block ~1 ~-1 ~1 #minecraft:rails run forceload add ~ ~ ~ ~
+execute as @e[type=minecart] run execute at @s if entity @e[type=!minecraft:minecart,distance=..0.5] if block ~1 ~1 ~1 #minecraft:rails run function vanillapluscarts:add_forceload
+execute as @e[type=minecart] run execute at @s if entity @e[type=!minecraft:minecart,distance=..0.5] if block ~1 ~-1 ~1 #minecraft:rails run function vanillapluscarts:add_forceload
 
-execute as @e[type=minecart] run execute at @s if entity @e[type=!minecraft:minecart,distance=..0.5] if block ~1 ~1 ~-1 #minecraft:rails run forceload add ~ ~ ~ ~ 
-execute as @e[type=minecart] run execute at @s if entity @e[type=!minecraft:minecart,distance=..0.5] if block ~1 ~-1 ~-1 #minecraft:rails run forceload add ~ ~ ~ ~
+execute as @e[type=minecart] run execute at @s if entity @e[type=!minecraft:minecart,distance=..0.5] if block ~1 ~1 ~-1 #minecraft:rails run function vanillapluscarts:add_forceload
+execute as @e[type=minecart] run execute at @s if entity @e[type=!minecraft:minecart,distance=..0.5] if block ~1 ~-1 ~-1 #minecraft:rails run function vanillapluscarts:add_forceload
 
 
-execute as @e[type=chest_minecart] unless data entity @s {LootTable:"minecraft:chests/abandoned_mineshaft"} run execute at @s if block ~1 ~ ~ #minecraft:rails run execute at @s run forceload add ~ ~ ~ ~ 
-execute as @e[type=chest_minecart] unless data entity @s {LootTable:"minecraft:chests/abandoned_mineshaft"} run execute at @s if block ~-1 ~ ~ #minecraft:rails run execute at @s run forceload add ~ ~ ~ ~
+execute as @e[type=chest_minecart] unless data entity @s {LootTable:"minecraft:chests/abandoned_mineshaft"} run execute at @s if block ~1 ~ ~ #minecraft:rails run execute at @s run function vanillapluscarts:add_forceload
+execute as @e[type=chest_minecart] unless data entity @s {LootTable:"minecraft:chests/abandoned_mineshaft"} run execute at @s if block ~-1 ~ ~ #minecraft:rails run execute at @s run function vanillapluscarts:add_forceload
 
-execute as @e[type=chest_minecart] unless data entity @s {LootTable:"minecraft:chests/abandoned_mineshaft"} run execute at @s if block ~ ~ ~1 #minecraft:rails run execute at @s run forceload add ~ ~ ~ ~ 
-execute as @e[type=chest_minecart] unless data entity @s {LootTable:"minecraft:chests/abandoned_mineshaft"} run execute at @s if block ~ ~ ~-1 #minecraft:rails run execute at @s run forceload add ~ ~ ~ ~
+execute as @e[type=chest_minecart] unless data entity @s {LootTable:"minecraft:chests/abandoned_mineshaft"} run execute at @s if block ~ ~ ~1 #minecraft:rails run execute at @s run function vanillapluscarts:add_forceload
+execute as @e[type=chest_minecart] unless data entity @s {LootTable:"minecraft:chests/abandoned_mineshaft"} run execute at @s if block ~ ~ ~-1 #minecraft:rails run execute at @s run function vanillapluscarts:add_forceload
 
-execute as @e[type=chest_minecart] unless data entity @s {LootTable:"minecraft:chests/abandoned_mineshaft"} run execute at @s if block ~1 ~ ~1 #minecraft:rails run execute at @s run forceload add ~ ~ ~ ~ 
-execute as @e[type=chest_minecart] unless data entity @s {LootTable:"minecraft:chests/abandoned_mineshaft"} run execute at @s if block ~-1 ~ ~-1 #minecraft:rails run execute at @s run forceload add ~ ~ ~ ~
+execute as @e[type=chest_minecart] unless data entity @s {LootTable:"minecraft:chests/abandoned_mineshaft"} run execute at @s if block ~1 ~ ~1 #minecraft:rails run execute at @s run function vanillapluscarts:add_forceload
+execute as @e[type=chest_minecart] unless data entity @s {LootTable:"minecraft:chests/abandoned_mineshaft"} run execute at @s if block ~-1 ~ ~-1 #minecraft:rails run execute at @s run function vanillapluscarts:add_forceload
 
-execute as @e[type=chest_minecart] unless data entity @s {LootTable:"minecraft:chests/abandoned_mineshaft"} run execute at @s if block ~1 ~ ~1 #minecraft:rails run execute at @s run forceload add ~ ~ ~ ~ 
-execute as @e[type=chest_minecart] unless data entity @s {LootTable:"minecraft:chests/abandoned_mineshaft"} run execute at @s if block ~1 ~ ~-1 #minecraft:rails run execute at @s run forceload add ~ ~ ~ ~
+execute as @e[type=chest_minecart] unless data entity @s {LootTable:"minecraft:chests/abandoned_mineshaft"} run execute at @s if block ~1 ~ ~1 #minecraft:rails run execute at @s run function vanillapluscarts:add_forceload
+execute as @e[type=chest_minecart] unless data entity @s {LootTable:"minecraft:chests/abandoned_mineshaft"} run execute at @s if block ~1 ~ ~-1 #minecraft:rails run execute at @s run function vanillapluscarts:add_forceload
 
-execute as @e[type=chest_minecart] unless data entity @s {LootTable:"minecraft:chests/abandoned_mineshaft"} run execute at @s if block ~1 ~1 ~ #minecraft:rails run execute at @s run forceload add ~ ~ ~ ~
-execute as @e[type=chest_minecart] unless data entity @s {LootTable:"minecraft:chests/abandoned_mineshaft"} run execute at @s if block ~1 ~-1 ~ #minecraft:rails run execute at @s run forceload add ~ ~ ~ ~ 
+execute as @e[type=chest_minecart] unless data entity @s {LootTable:"minecraft:chests/abandoned_mineshaft"} run execute at @s if block ~1 ~1 ~ #minecraft:rails run execute at @s run function vanillapluscarts:add_forceload
+execute as @e[type=chest_minecart] unless data entity @s {LootTable:"minecraft:chests/abandoned_mineshaft"} run execute at @s if block ~1 ~-1 ~ #minecraft:rails run execute at @s run function vanillapluscarts:add_forceload
 
-execute as @e[type=chest_minecart] unless data entity @s {LootTable:"minecraft:chests/abandoned_mineshaft"} run execute at @s if block ~-1 ~1 ~ #minecraft:rails run execute at @s run forceload add ~ ~ ~ ~
-execute as @e[type=chest_minecart] unless data entity @s {LootTable:"minecraft:chests/abandoned_mineshaft"} run execute at @s if block ~-1 ~-1 ~ #minecraft:rails run execute at @s run forceload add ~ ~ ~ ~
+execute as @e[type=chest_minecart] unless data entity @s {LootTable:"minecraft:chests/abandoned_mineshaft"} run execute at @s if block ~-1 ~1 ~ #minecraft:rails run execute at @s run function vanillapluscarts:add_forceload
+execute as @e[type=chest_minecart] unless data entity @s {LootTable:"minecraft:chests/abandoned_mineshaft"} run execute at @s if block ~-1 ~-1 ~ #minecraft:rails run execute at @s run function vanillapluscarts:add_forceload
 
-execute as @e[type=chest_minecart] unless data entity @s {LootTable:"minecraft:chests/abandoned_mineshaft"} run execute at @s if block ~ ~1 ~1 #minecraft:rails run execute at @s run forceload add ~ ~ ~ ~ 
-execute as @e[type=chest_minecart] unless data entity @s {LootTable:"minecraft:chests/abandoned_mineshaft"} run execute at @s if block ~ ~-1 ~1 #minecraft:rails run execute at @s run forceload add ~ ~ ~ ~ 
+execute as @e[type=chest_minecart] unless data entity @s {LootTable:"minecraft:chests/abandoned_mineshaft"} run execute at @s if block ~ ~1 ~1 #minecraft:rails run execute at @s run function vanillapluscarts:add_forceload
+execute as @e[type=chest_minecart] unless data entity @s {LootTable:"minecraft:chests/abandoned_mineshaft"} run execute at @s if block ~ ~-1 ~1 #minecraft:rails run execute at @s run function vanillapluscarts:add_forceload
 
-execute as @e[type=chest_minecart] unless data entity @s {LootTable:"minecraft:chests/abandoned_mineshaft"} run execute at @s if block ~ ~1 ~-1 #minecraft:rails run execute at @s run forceload add ~ ~ ~ ~
-execute as @e[type=chest_minecart] unless data entity @s {LootTable:"minecraft:chests/abandoned_mineshaft"} run execute at @s if block ~ ~-1 ~-1 #minecraft:rails run execute at @s run forceload add ~ ~ ~ ~
+execute as @e[type=chest_minecart] unless data entity @s {LootTable:"minecraft:chests/abandoned_mineshaft"} run execute at @s if block ~ ~1 ~-1 #minecraft:rails run execute at @s run function vanillapluscarts:add_forceload
+execute as @e[type=chest_minecart] unless data entity @s {LootTable:"minecraft:chests/abandoned_mineshaft"} run execute at @s if block ~ ~-1 ~-1 #minecraft:rails run execute at @s run function vanillapluscarts:add_forceload
 
-execute as @e[type=chest_minecart] unless data entity @s {LootTable:"minecraft:chests/abandoned_mineshaft"} run execute at @s if block ~1 ~1 ~1 #minecraft:rails run execute at @s run forceload add ~ ~ ~ ~ 
-execute as @e[type=chest_minecart] unless data entity @s {LootTable:"minecraft:chests/abandoned_mineshaft"} run execute at @s if block ~1 ~-1 ~1 #minecraft:rails run execute at @s run forceload add ~ ~ ~ ~ 
+execute as @e[type=chest_minecart] unless data entity @s {LootTable:"minecraft:chests/abandoned_mineshaft"} run execute at @s if block ~1 ~1 ~1 #minecraft:rails run execute at @s run function vanillapluscarts:add_forceload
+execute as @e[type=chest_minecart] unless data entity @s {LootTable:"minecraft:chests/abandoned_mineshaft"} run execute at @s if block ~1 ~-1 ~1 #minecraft:rails run execute at @s run function vanillapluscarts:add_forceload
 
-execute as @e[type=chest_minecart] unless data entity @s {LootTable:"minecraft:chests/abandoned_mineshaft"} run execute at @s if block ~-1 ~1 ~-1 #minecraft:rails run execute at @s run forceload add ~ ~ ~ ~
-execute as @e[type=chest_minecart] unless data entity @s {LootTable:"minecraft:chests/abandoned_mineshaft"} run execute at @s if block ~-1 ~-1 ~-1 #minecraft:rails run execute at @s run forceload add ~ ~ ~ ~
+execute as @e[type=chest_minecart] unless data entity @s {LootTable:"minecraft:chests/abandoned_mineshaft"} run execute at @s if block ~-1 ~1 ~-1 #minecraft:rails run execute at @s run function vanillapluscarts:add_forceload
+execute as @e[type=chest_minecart] unless data entity @s {LootTable:"minecraft:chests/abandoned_mineshaft"} run execute at @s if block ~-1 ~-1 ~-1 #minecraft:rails run execute at @s run function vanillapluscarts:add_forceload
 
-execute as @e[type=chest_minecart] unless data entity @s {LootTable:"minecraft:chests/abandoned_mineshaft"} run execute at @s if block ~1 ~1 ~1 #minecraft:rails run execute at @s run forceload add ~ ~ ~ ~ 
-execute as @e[type=chest_minecart] unless data entity @s {LootTable:"minecraft:chests/abandoned_mineshaft"} run execute at @s if block ~1 ~-1 ~1 #minecraft:rails run execute at @s run forceload add ~ ~ ~ ~ 
+execute as @e[type=chest_minecart] unless data entity @s {LootTable:"minecraft:chests/abandoned_mineshaft"} run execute at @s if block ~1 ~1 ~1 #minecraft:rails run execute at @s run function vanillapluscarts:add_forceload
+execute as @e[type=chest_minecart] unless data entity @s {LootTable:"minecraft:chests/abandoned_mineshaft"} run execute at @s if block ~1 ~-1 ~1 #minecraft:rails run execute at @s run function vanillapluscarts:add_forceload
 
-execute as @e[type=chest_minecart] unless data entity @s {LootTable:"minecraft:chests/abandoned_mineshaft"} run execute at @s if block ~1 ~1 ~-1 #minecraft:rails run execute at @s run forceload add ~ ~ ~ ~
-execute as @e[type=chest_minecart] unless data entity @s {LootTable:"minecraft:chests/abandoned_mineshaft"} run execute at @s if block ~1 ~-1 ~-1 #minecraft:rails run execute at @s run forceload add ~ ~ ~ ~
+execute as @e[type=chest_minecart] unless data entity @s {LootTable:"minecraft:chests/abandoned_mineshaft"} run execute at @s if block ~1 ~1 ~-1 #minecraft:rails run execute at @s run function vanillapluscarts:add_forceload
+execute as @e[type=chest_minecart] unless data entity @s {LootTable:"minecraft:chests/abandoned_mineshaft"} run execute at @s if block ~1 ~-1 ~-1 #minecraft:rails run execute at @s run function vanillapluscarts:add_forceload

--- a/darcenos-minecarts/data/vanillapluscarts/function/add_forceload.mcfunction
+++ b/darcenos-minecarts/data/vanillapluscarts/function/add_forceload.mcfunction
@@ -1,0 +1,3 @@
+execute unless function vanillapluscarts:forceload_query run function vanillapluscarts:log_forceload
+
+forceload add ~ ~ ~ ~

--- a/darcenos-minecarts/data/vanillapluscarts/function/forceload_query.mcfunction
+++ b/darcenos-minecarts/data/vanillapluscarts/function/forceload_query.mcfunction
@@ -1,0 +1,1 @@
+return run forceload query ~ ~

--- a/darcenos-minecarts/data/vanillapluscarts/function/forceload_remove.mcfunction
+++ b/darcenos-minecarts/data/vanillapluscarts/function/forceload_remove.mcfunction
@@ -1,0 +1,1 @@
+$forceload remove $(x) $(z)

--- a/darcenos-minecarts/data/vanillapluscarts/function/load.mcfunction
+++ b/darcenos-minecarts/data/vanillapluscarts/function/load.mcfunction
@@ -1,2 +1,4 @@
 scoreboard objectives add VanillaPlusCartsXSpeed dummy
 scoreboard objectives add VanillaPlusCartsZSpeed dummy
+
+data merge storage vanillapluscarts:global {chunks:[]}

--- a/darcenos-minecarts/data/vanillapluscarts/function/load.mcfunction
+++ b/darcenos-minecarts/data/vanillapluscarts/function/load.mcfunction
@@ -1,4 +1,4 @@
 scoreboard objectives add VanillaPlusCartsXSpeed dummy
 scoreboard objectives add VanillaPlusCartsZSpeed dummy
 
-data merge storage vanillapluscarts:global {chunks:[]}
+execute unless data storage vanillapluscarts:global chunks run data merge storage vanillapluscarts:global {chunks:[]}

--- a/darcenos-minecarts/data/vanillapluscarts/function/log_forceload.mcfunction
+++ b/darcenos-minecarts/data/vanillapluscarts/function/log_forceload.mcfunction
@@ -1,0 +1,5 @@
+data modify storage vanillapluscarts:global chunks insert 0 value {}
+data modify storage vanillapluscarts:global chunks[0].z set from entity @s Pos[2]
+execute store result storage vanillapluscarts:global chunks[0].z int 1 run data get storage vanillapluscarts:global chunks[0].z
+data modify storage vanillapluscarts:global chunks[0].x set from entity @s Pos[0]
+execute store result storage vanillapluscarts:global chunks[0].x int 1 run data get storage vanillapluscarts:global chunks[0].x

--- a/darcenos-minecarts/data/vanillapluscarts/function/remove_all_forceload.mcfunction
+++ b/darcenos-minecarts/data/vanillapluscarts/function/remove_all_forceload.mcfunction
@@ -1,4 +1,4 @@
-execute store success storage vanillapluscarts:global success byte 1 run function vanillapluscarts:forceload_remove with storage vanillapluscarts:global chunks[0]
+execute run function vanillapluscarts:forceload_remove with storage vanillapluscarts:global chunks[0]
 
 # pop
 data remove storage vanillapluscarts:global chunks[0]

--- a/darcenos-minecarts/data/vanillapluscarts/function/remove_all_forceload.mcfunction
+++ b/darcenos-minecarts/data/vanillapluscarts/function/remove_all_forceload.mcfunction
@@ -1,0 +1,7 @@
+execute store success storage vanillapluscarts:global success byte 1 run function vanillapluscarts:forceload_remove with storage vanillapluscarts:global chunks[0]
+
+# pop
+data remove storage vanillapluscarts:global chunks[0]
+
+# recurse
+execute if data storage vanillapluscarts:global chunks[0] run function vanillapluscarts:remove_all_forceload

--- a/darcenos-minecarts/data/vanillapluscarts/function/tick.mcfunction
+++ b/darcenos-minecarts/data/vanillapluscarts/function/tick.mcfunction
@@ -1,77 +1,77 @@
 execute as @e[type=minecraft:minecart] at @s if entity @e[type=!minecraft:minecart,distance=..0.5] run function vanillapluscarts:speed
 execute as @e[type=minecraft:chest_minecart] at @s if entity @e[type=!minecraft:minecart,distance=..0.5] run function vanillapluscarts:speed
 
-forceload remove all
+function vanillapluscarts:remove_all_forceload
 
-execute as @e[type=minecart] run execute at @s if entity @e[type=!minecraft:minecart,distance=..0.5] if block ~1 ~ ~ #minecraft:rails run forceload add ~ ~ ~ ~
-execute as @e[type=minecart] run execute at @s if entity @e[type=!minecraft:minecart,distance=..0.5] if block ~-1 ~ ~ #minecraft:rails run forceload add ~ ~ ~ ~ 
+execute as @e[type=minecart] run execute at @s if entity @e[type=!minecraft:minecart,distance=..0.5] if block ~1 ~ ~ #minecraft:rails run function vanillapluscarts:add_forceload
+execute as @e[type=minecart] run execute at @s if entity @e[type=!minecraft:minecart,distance=..0.5] if block ~-1 ~ ~ #minecraft:rails run function vanillapluscarts:add_forceload
 
-execute as @e[type=minecart] run execute at @s if entity @e[type=!minecraft:minecart,distance=..0.5] if block ~ ~ ~1 #minecraft:rails run forceload add ~ ~ ~ ~ 
-execute as @e[type=minecart] run execute at @s if entity @e[type=!minecraft:minecart,distance=..0.5] if block ~ ~ ~-1 #minecraft:rails run forceload add ~ ~ ~ ~
+execute as @e[type=minecart] run execute at @s if entity @e[type=!minecraft:minecart,distance=..0.5] if block ~ ~ ~1 #minecraft:rails run function vanillapluscarts:add_forceload
+execute as @e[type=minecart] run execute at @s if entity @e[type=!minecraft:minecart,distance=..0.5] if block ~ ~ ~-1 #minecraft:rails run function vanillapluscarts:add_forceload
 
-execute as @e[type=minecart] run execute at @s if entity @e[type=!minecraft:minecart,distance=..0.5] if block ~1 ~ ~1 #minecraft:rails run forceload add ~ ~ ~ ~ 
-execute as @e[type=minecart] run execute at @s if entity @e[type=!minecraft:minecart,distance=..0.5] if block ~-1 ~ ~-1 #minecraft:rails run forceload add ~ ~ ~ ~
+execute as @e[type=minecart] run execute at @s if entity @e[type=!minecraft:minecart,distance=..0.5] if block ~1 ~ ~1 #minecraft:rails run function vanillapluscarts:add_forceload
+execute as @e[type=minecart] run execute at @s if entity @e[type=!minecraft:minecart,distance=..0.5] if block ~-1 ~ ~-1 #minecraft:rails run function vanillapluscarts:add_forceload
 
-execute as @e[type=minecart] run execute at @s if entity @e[type=!minecraft:minecart,distance=..0.5] if block ~1 ~ ~1 #minecraft:rails run forceload add ~ ~ ~ ~ 
-execute as @e[type=minecart] run execute at @s if entity @e[type=!minecraft:minecart,distance=..0.5] if block ~1 ~ ~-1 #minecraft:rails run forceload add ~ ~ ~ ~
+execute as @e[type=minecart] run execute at @s if entity @e[type=!minecraft:minecart,distance=..0.5] if block ~1 ~ ~1 #minecraft:rails run function vanillapluscarts:add_forceload
+execute as @e[type=minecart] run execute at @s if entity @e[type=!minecraft:minecart,distance=..0.5] if block ~1 ~ ~-1 #minecraft:rails run function vanillapluscarts:add_forceload
 
-execute as @e[type=minecart] run execute at @s if entity @e[type=!minecraft:minecart,distance=..0.5] if block ~1 ~1 ~ #minecraft:rails run forceload add ~ ~ ~ ~ 
-execute as @e[type=minecart] run execute at @s if entity @e[type=!minecraft:minecart,distance=..0.5] if block ~1 ~-1 ~ #minecraft:rails run forceload add ~ ~ ~ ~
+execute as @e[type=minecart] run execute at @s if entity @e[type=!minecraft:minecart,distance=..0.5] if block ~1 ~1 ~ #minecraft:rails run function vanillapluscarts:add_forceload
+execute as @e[type=minecart] run execute at @s if entity @e[type=!minecraft:minecart,distance=..0.5] if block ~1 ~-1 ~ #minecraft:rails run function vanillapluscarts:add_forceload
 
-execute as @e[type=minecart] run execute at @s if entity @e[type=!minecraft:minecart,distance=..0.5] if block ~-1 ~1 ~ #minecraft:rails run forceload add ~ ~ ~ ~ 
-execute as @e[type=minecart] run execute at @s if entity @e[type=!minecraft:minecart,distance=..0.5] if block ~-1 ~-1 ~ #minecraft:rails run forceload add ~ ~ ~ ~
+execute as @e[type=minecart] run execute at @s if entity @e[type=!minecraft:minecart,distance=..0.5] if block ~-1 ~1 ~ #minecraft:rails run function vanillapluscarts:add_forceload
+execute as @e[type=minecart] run execute at @s if entity @e[type=!minecraft:minecart,distance=..0.5] if block ~-1 ~-1 ~ #minecraft:rails run function vanillapluscarts:add_forceload
 
-execute as @e[type=minecart] run execute at @s if entity @e[type=!minecraft:minecart,distance=..0.5] if block ~ ~1 ~1 #minecraft:rails run forceload add ~ ~ ~ ~ 
-execute as @e[type=minecart] run execute at @s if entity @e[type=!minecraft:minecart,distance=..0.5] if block ~ ~-1 ~1 #minecraft:rails run forceload add ~ ~ ~ ~
+execute as @e[type=minecart] run execute at @s if entity @e[type=!minecraft:minecart,distance=..0.5] if block ~ ~1 ~1 #minecraft:rails run function vanillapluscarts:add_forceload
+execute as @e[type=minecart] run execute at @s if entity @e[type=!minecraft:minecart,distance=..0.5] if block ~ ~-1 ~1 #minecraft:rails run function vanillapluscarts:add_forceload
 
-execute as @e[type=minecart] run execute at @s if entity @e[type=!minecraft:minecart,distance=..0.5] if block ~ ~1 ~-1 #minecraft:rails run forceload add ~ ~ ~ ~ 
-execute as @e[type=minecart] run execute at @s if entity @e[type=!minecraft:minecart,distance=..0.5] if block ~ ~-1 ~-1 #minecraft:rails run forceload add ~ ~ ~ ~
+execute as @e[type=minecart] run execute at @s if entity @e[type=!minecraft:minecart,distance=..0.5] if block ~ ~1 ~-1 #minecraft:rails run function vanillapluscarts:add_forceload
+execute as @e[type=minecart] run execute at @s if entity @e[type=!minecraft:minecart,distance=..0.5] if block ~ ~-1 ~-1 #minecraft:rails run function vanillapluscarts:add_forceload
 
-execute as @e[type=minecart] run execute at @s if entity @e[type=!minecraft:minecart,distance=..0.5] if block ~1 ~1 ~1 #minecraft:rails run forceload add ~ ~ ~ ~ 
-execute as @e[type=minecart] run execute at @s if entity @e[type=!minecraft:minecart,distance=..0.5] if block ~1 ~-1 ~1 #minecraft:rails run forceload add ~ ~ ~ ~
+execute as @e[type=minecart] run execute at @s if entity @e[type=!minecraft:minecart,distance=..0.5] if block ~1 ~1 ~1 #minecraft:rails run function vanillapluscarts:add_forceload
+execute as @e[type=minecart] run execute at @s if entity @e[type=!minecraft:minecart,distance=..0.5] if block ~1 ~-1 ~1 #minecraft:rails run function vanillapluscarts:add_forceload
 
-execute as @e[type=minecart] run execute at @s if entity @e[type=!minecraft:minecart,distance=..0.5] if block ~-1 ~1 ~-1 #minecraft:rails run forceload add ~ ~ ~ ~ 
-execute as @e[type=minecart] run execute at @s if entity @e[type=!minecraft:minecart,distance=..0.5] if block ~-1 ~-1 ~-1 #minecraft:rails run forceload add ~ ~ ~ ~
+execute as @e[type=minecart] run execute at @s if entity @e[type=!minecraft:minecart,distance=..0.5] if block ~-1 ~1 ~-1 #minecraft:rails run function vanillapluscarts:add_forceload
+execute as @e[type=minecart] run execute at @s if entity @e[type=!minecraft:minecart,distance=..0.5] if block ~-1 ~-1 ~-1 #minecraft:rails run function vanillapluscarts:add_forceload
 
-execute as @e[type=minecart] run execute at @s if entity @e[type=!minecraft:minecart,distance=..0.5] if block ~1 ~1 ~1 #minecraft:rails run forceload add ~ ~ ~ ~ 
-execute as @e[type=minecart] run execute at @s if entity @e[type=!minecraft:minecart,distance=..0.5] if block ~1 ~-1 ~1 #minecraft:rails run forceload add ~ ~ ~ ~
+execute as @e[type=minecart] run execute at @s if entity @e[type=!minecraft:minecart,distance=..0.5] if block ~1 ~1 ~1 #minecraft:rails run function vanillapluscarts:add_forceload
+execute as @e[type=minecart] run execute at @s if entity @e[type=!minecraft:minecart,distance=..0.5] if block ~1 ~-1 ~1 #minecraft:rails run function vanillapluscarts:add_forceload
 
-execute as @e[type=minecart] run execute at @s if entity @e[type=!minecraft:minecart,distance=..0.5] if block ~1 ~1 ~-1 #minecraft:rails run forceload add ~ ~ ~ ~ 
-execute as @e[type=minecart] run execute at @s if entity @e[type=!minecraft:minecart,distance=..0.5] if block ~1 ~-1 ~-1 #minecraft:rails run forceload add ~ ~ ~ ~
+execute as @e[type=minecart] run execute at @s if entity @e[type=!minecraft:minecart,distance=..0.5] if block ~1 ~1 ~-1 #minecraft:rails run function vanillapluscarts:add_forceload
+execute as @e[type=minecart] run execute at @s if entity @e[type=!minecraft:minecart,distance=..0.5] if block ~1 ~-1 ~-1 #minecraft:rails run function vanillapluscarts:add_forceload
 
 
-execute as @e[type=chest_minecart] unless data entity @s {LootTable:"minecraft:chests/abandoned_mineshaft"} run execute at @s if block ~1 ~ ~ #minecraft:rails run execute at @s run forceload add ~ ~ ~ ~ 
-execute as @e[type=chest_minecart] unless data entity @s {LootTable:"minecraft:chests/abandoned_mineshaft"} run execute at @s if block ~-1 ~ ~ #minecraft:rails run execute at @s run forceload add ~ ~ ~ ~
+execute as @e[type=chest_minecart] unless data entity @s {LootTable:"minecraft:chests/abandoned_mineshaft"} run execute at @s if block ~1 ~ ~ #minecraft:rails run execute at @s run function vanillapluscarts:add_forceload
+execute as @e[type=chest_minecart] unless data entity @s {LootTable:"minecraft:chests/abandoned_mineshaft"} run execute at @s if block ~-1 ~ ~ #minecraft:rails run execute at @s run function vanillapluscarts:add_forceload
 
-execute as @e[type=chest_minecart] unless data entity @s {LootTable:"minecraft:chests/abandoned_mineshaft"} run execute at @s if block ~ ~ ~1 #minecraft:rails run execute at @s run forceload add ~ ~ ~ ~ 
-execute as @e[type=chest_minecart] unless data entity @s {LootTable:"minecraft:chests/abandoned_mineshaft"} run execute at @s if block ~ ~ ~-1 #minecraft:rails run execute at @s run forceload add ~ ~ ~ ~
+execute as @e[type=chest_minecart] unless data entity @s {LootTable:"minecraft:chests/abandoned_mineshaft"} run execute at @s if block ~ ~ ~1 #minecraft:rails run execute at @s run function vanillapluscarts:add_forceload
+execute as @e[type=chest_minecart] unless data entity @s {LootTable:"minecraft:chests/abandoned_mineshaft"} run execute at @s if block ~ ~ ~-1 #minecraft:rails run execute at @s run function vanillapluscarts:add_forceload
 
-execute as @e[type=chest_minecart] unless data entity @s {LootTable:"minecraft:chests/abandoned_mineshaft"} run execute at @s if block ~1 ~ ~1 #minecraft:rails run execute at @s run forceload add ~ ~ ~ ~ 
-execute as @e[type=chest_minecart] unless data entity @s {LootTable:"minecraft:chests/abandoned_mineshaft"} run execute at @s if block ~-1 ~ ~-1 #minecraft:rails run execute at @s run forceload add ~ ~ ~ ~
+execute as @e[type=chest_minecart] unless data entity @s {LootTable:"minecraft:chests/abandoned_mineshaft"} run execute at @s if block ~1 ~ ~1 #minecraft:rails run execute at @s run function vanillapluscarts:add_forceload
+execute as @e[type=chest_minecart] unless data entity @s {LootTable:"minecraft:chests/abandoned_mineshaft"} run execute at @s if block ~-1 ~ ~-1 #minecraft:rails run execute at @s run function vanillapluscarts:add_forceload
 
-execute as @e[type=chest_minecart] unless data entity @s {LootTable:"minecraft:chests/abandoned_mineshaft"} run execute at @s if block ~1 ~ ~1 #minecraft:rails run execute at @s run forceload add ~ ~ ~ ~ 
-execute as @e[type=chest_minecart] unless data entity @s {LootTable:"minecraft:chests/abandoned_mineshaft"} run execute at @s if block ~1 ~ ~-1 #minecraft:rails run execute at @s run forceload add ~ ~ ~ ~
+execute as @e[type=chest_minecart] unless data entity @s {LootTable:"minecraft:chests/abandoned_mineshaft"} run execute at @s if block ~1 ~ ~1 #minecraft:rails run execute at @s run function vanillapluscarts:add_forceload
+execute as @e[type=chest_minecart] unless data entity @s {LootTable:"minecraft:chests/abandoned_mineshaft"} run execute at @s if block ~1 ~ ~-1 #minecraft:rails run execute at @s run function vanillapluscarts:add_forceload
 
-execute as @e[type=chest_minecart] unless data entity @s {LootTable:"minecraft:chests/abandoned_mineshaft"} run execute at @s if block ~1 ~1 ~ #minecraft:rails run execute at @s run forceload add ~ ~ ~ ~
-execute as @e[type=chest_minecart] unless data entity @s {LootTable:"minecraft:chests/abandoned_mineshaft"} run execute at @s if block ~1 ~-1 ~ #minecraft:rails run execute at @s run forceload add ~ ~ ~ ~ 
+execute as @e[type=chest_minecart] unless data entity @s {LootTable:"minecraft:chests/abandoned_mineshaft"} run execute at @s if block ~1 ~1 ~ #minecraft:rails run execute at @s run function vanillapluscarts:add_forceload
+execute as @e[type=chest_minecart] unless data entity @s {LootTable:"minecraft:chests/abandoned_mineshaft"} run execute at @s if block ~1 ~-1 ~ #minecraft:rails run execute at @s run function vanillapluscarts:add_forceload
 
-execute as @e[type=chest_minecart] unless data entity @s {LootTable:"minecraft:chests/abandoned_mineshaft"} run execute at @s if block ~-1 ~1 ~ #minecraft:rails run execute at @s run forceload add ~ ~ ~ ~
-execute as @e[type=chest_minecart] unless data entity @s {LootTable:"minecraft:chests/abandoned_mineshaft"} run execute at @s if block ~-1 ~-1 ~ #minecraft:rails run execute at @s run forceload add ~ ~ ~ ~
+execute as @e[type=chest_minecart] unless data entity @s {LootTable:"minecraft:chests/abandoned_mineshaft"} run execute at @s if block ~-1 ~1 ~ #minecraft:rails run execute at @s run function vanillapluscarts:add_forceload
+execute as @e[type=chest_minecart] unless data entity @s {LootTable:"minecraft:chests/abandoned_mineshaft"} run execute at @s if block ~-1 ~-1 ~ #minecraft:rails run execute at @s run function vanillapluscarts:add_forceload
 
-execute as @e[type=chest_minecart] unless data entity @s {LootTable:"minecraft:chests/abandoned_mineshaft"} run execute at @s if block ~ ~1 ~1 #minecraft:rails run execute at @s run forceload add ~ ~ ~ ~ 
-execute as @e[type=chest_minecart] unless data entity @s {LootTable:"minecraft:chests/abandoned_mineshaft"} run execute at @s if block ~ ~-1 ~1 #minecraft:rails run execute at @s run forceload add ~ ~ ~ ~ 
+execute as @e[type=chest_minecart] unless data entity @s {LootTable:"minecraft:chests/abandoned_mineshaft"} run execute at @s if block ~ ~1 ~1 #minecraft:rails run execute at @s run function vanillapluscarts:add_forceload
+execute as @e[type=chest_minecart] unless data entity @s {LootTable:"minecraft:chests/abandoned_mineshaft"} run execute at @s if block ~ ~-1 ~1 #minecraft:rails run execute at @s run function vanillapluscarts:add_forceload
 
-execute as @e[type=chest_minecart] unless data entity @s {LootTable:"minecraft:chests/abandoned_mineshaft"} run execute at @s if block ~ ~1 ~-1 #minecraft:rails run execute at @s run forceload add ~ ~ ~ ~
-execute as @e[type=chest_minecart] unless data entity @s {LootTable:"minecraft:chests/abandoned_mineshaft"} run execute at @s if block ~ ~-1 ~-1 #minecraft:rails run execute at @s run forceload add ~ ~ ~ ~
+execute as @e[type=chest_minecart] unless data entity @s {LootTable:"minecraft:chests/abandoned_mineshaft"} run execute at @s if block ~ ~1 ~-1 #minecraft:rails run execute at @s run function vanillapluscarts:add_forceload
+execute as @e[type=chest_minecart] unless data entity @s {LootTable:"minecraft:chests/abandoned_mineshaft"} run execute at @s if block ~ ~-1 ~-1 #minecraft:rails run execute at @s run function vanillapluscarts:add_forceload
 
-execute as @e[type=chest_minecart] unless data entity @s {LootTable:"minecraft:chests/abandoned_mineshaft"} run execute at @s if block ~1 ~1 ~1 #minecraft:rails run execute at @s run forceload add ~ ~ ~ ~ 
-execute as @e[type=chest_minecart] unless data entity @s {LootTable:"minecraft:chests/abandoned_mineshaft"} run execute at @s if block ~1 ~-1 ~1 #minecraft:rails run execute at @s run forceload add ~ ~ ~ ~ 
+execute as @e[type=chest_minecart] unless data entity @s {LootTable:"minecraft:chests/abandoned_mineshaft"} run execute at @s if block ~1 ~1 ~1 #minecraft:rails run execute at @s run function vanillapluscarts:add_forceload
+execute as @e[type=chest_minecart] unless data entity @s {LootTable:"minecraft:chests/abandoned_mineshaft"} run execute at @s if block ~1 ~-1 ~1 #minecraft:rails run execute at @s run function vanillapluscarts:add_forceload
 
-execute as @e[type=chest_minecart] unless data entity @s {LootTable:"minecraft:chests/abandoned_mineshaft"} run execute at @s if block ~-1 ~1 ~-1 #minecraft:rails run execute at @s run forceload add ~ ~ ~ ~
-execute as @e[type=chest_minecart] unless data entity @s {LootTable:"minecraft:chests/abandoned_mineshaft"} run execute at @s if block ~-1 ~-1 ~-1 #minecraft:rails run execute at @s run forceload add ~ ~ ~ ~
+execute as @e[type=chest_minecart] unless data entity @s {LootTable:"minecraft:chests/abandoned_mineshaft"} run execute at @s if block ~-1 ~1 ~-1 #minecraft:rails run execute at @s run function vanillapluscarts:add_forceload
+execute as @e[type=chest_minecart] unless data entity @s {LootTable:"minecraft:chests/abandoned_mineshaft"} run execute at @s if block ~-1 ~-1 ~-1 #minecraft:rails run execute at @s run function vanillapluscarts:add_forceload
 
-execute as @e[type=chest_minecart] unless data entity @s {LootTable:"minecraft:chests/abandoned_mineshaft"} run execute at @s if block ~1 ~1 ~1 #minecraft:rails run execute at @s run forceload add ~ ~ ~ ~ 
-execute as @e[type=chest_minecart] unless data entity @s {LootTable:"minecraft:chests/abandoned_mineshaft"} run execute at @s if block ~1 ~-1 ~1 #minecraft:rails run execute at @s run forceload add ~ ~ ~ ~ 
+execute as @e[type=chest_minecart] unless data entity @s {LootTable:"minecraft:chests/abandoned_mineshaft"} run execute at @s if block ~1 ~1 ~1 #minecraft:rails run execute at @s run function vanillapluscarts:add_forceload
+execute as @e[type=chest_minecart] unless data entity @s {LootTable:"minecraft:chests/abandoned_mineshaft"} run execute at @s if block ~1 ~-1 ~1 #minecraft:rails run execute at @s run function vanillapluscarts:add_forceload
 
-execute as @e[type=chest_minecart] unless data entity @s {LootTable:"minecraft:chests/abandoned_mineshaft"} run execute at @s if block ~1 ~1 ~-1 #minecraft:rails run execute at @s run forceload add ~ ~ ~ ~
-execute as @e[type=chest_minecart] unless data entity @s {LootTable:"minecraft:chests/abandoned_mineshaft"} run execute at @s if block ~1 ~-1 ~-1 #minecraft:rails run execute at @s run forceload add ~ ~ ~ ~
+execute as @e[type=chest_minecart] unless data entity @s {LootTable:"minecraft:chests/abandoned_mineshaft"} run execute at @s if block ~1 ~1 ~-1 #minecraft:rails run execute at @s run function vanillapluscarts:add_forceload
+execute as @e[type=chest_minecart] unless data entity @s {LootTable:"minecraft:chests/abandoned_mineshaft"} run execute at @s if block ~1 ~-1 ~-1 #minecraft:rails run execute at @s run function vanillapluscarts:add_forceload


### PR DESCRIPTION
Made some changes for my own use that stops the datapack from clobbering all forceloads by running `forceload remove all`, feel free to merge if you want. As far as I can tell it works perfectly, and doesn't remove any forceloads that it did not itself set up in the first place.